### PR TITLE
Feat count param

### DIFF
--- a/Step3a_data_cleaning.Rmd
+++ b/Step3a_data_cleaning.Rmd
@@ -13,7 +13,7 @@ params:
     data_path: "/oscar/data/tkartzin/projects"
     
     #update these for your analysis
-    step_3a_analysis_date: "20240529" #YYYYMMDD
+    step_3a_analysis_date: "20241009" #YYYYMMDD
     project_code: "test"
     seq_run_name: ["URI_20221013", "URI_20230519"] #these are the folder names in the 'data/tkartzin/projects/<project_code>' dir
     step_1_analysis_date: ["20240502_tdivoll", "20240430_tdivoll"] #make sure these dates are in the same order as the appropriate `seq_run_name` folders
@@ -79,7 +79,7 @@ Now that all the controls and potentially bad samples were removed in Step 1c, w
 
 #### Combine remaining sequences into one FASTA and dereplicate
 ```{bash}
-source ~/.bash_profile
+source ~/.bashrc
 conda activate /users/${user}/.conda/envs/obitools-env
 cd $output_path
 
@@ -89,7 +89,7 @@ obicount all.uniq.fasta --without-progress-bar
 
 #### Filter results to just `count` and `merged_sample` attributes in FASTA headers
 ```{bash}
-source ~/.bash_profile
+source ~/.bashrc
 conda activate /users/${user}/.conda/envs/obitools-env
 cd $output_path
 
@@ -98,7 +98,7 @@ obiannotate -k count -k merged_sample all.uniq.fasta > $$ ; mv $$ all.uniq.fasta
 
 #### Inspect the `count` attribute
 ```{bash}
-source ~/.bash_profile
+source ~/.bashrc
 conda activate /users/${user}/.conda/envs/obitools-env
 cd $output_path
 
@@ -116,7 +116,7 @@ obistat -c count all.uniq.fasta --without-progress-bar | sort -nk1 | tail -20 | 
 
 #### Create a tabulated file for counts per sequence read
 ```{bash}
-source ~/.bash_profile
+source ~/.bashrc
 conda activate /users/${user}/.conda/envs/obitools-env
 cd $output_path
 
@@ -127,7 +127,7 @@ obitab -o all.uniq.fasta > all.uniq.tab
 Keep only the sequences having a count greater or equal to `min_read_length` and a length shorter than `max_read_length` bp (this should be changed depending on marker and filtering criteria)
 
 ```{bash}
-source ~/.bash_profile
+source ~/.bashrc
 conda activate /users/${user}/.conda/envs/obitools-env
 cd $output_path
 
@@ -138,7 +138,7 @@ obigrep -l $min_read_length -L $max_read_length -p "count>=$copy_threshold" all.
 We keep the head sequences (-H option) that are sequences with no variants with a count greater than 5% of their own count (-r 0.05 option). 
 **Note:**This step takes a while.
 ```{bash}
-source ~/.bash_profile
+source ~/.bashrc
 conda activate /users/${user}/.conda/envs/obitools-env
 cd $output_path
 
@@ -147,7 +147,7 @@ obiclean -s merged_sample -r $clean_threshold -H ${date}_all.uniq.fasta > ${date
 #### Create a tabulated file to check the number of sequence reads in each sample
 
 ```{bash}
-source ~/.bash_profile
+source ~/.bashrc
 conda activate /users/${user}/.conda/envs/obitools-env
 cd $output_path
 


### PR DESCRIPTION
This make the copy number threshold used in `obigrep` a parameter so that users can filter at different thresholds than just true singletons.