### PR TITLE
remove todaydate param and add date for step_3c

### DIFF
--- a/Step4a_create_phyloseq_global.Rmd
+++ b/Step4a_create_phyloseq_global.Rmd
@@ -8,7 +8,6 @@ html_document:
   toc: true
 params:
     #don't change these
-    todaydate: !r (format(Sys.Date(), "%Y%m%d"))
     user: !r Sys.getenv("LOGNAME")
     data_path: "/oscar/data/tkartzin/projects"
     ref_lib_path: "/oscar/data/tkartzin/global_ref_lib"


### PR DESCRIPTION
This fixes 4a notebook that still had the `todaydate` param. it is better to have the user input dates for steps 3b and 3c to allow the flexibility to run the pipeline in pieces on separate days.