### PR TITLE
Update Step4a_create_phyloseq_global.Rmd

### DIFF
--- a/Step4a_create_phyloseq_global.Rmd
+++ b/Step4a_create_phyloseq_global.Rmd
@@ -262,7 +262,7 @@ params
 
 ## Copy over OTU, TAX, samples to "merged_runs"
 ```{r}
-output_path <- file.path(params$data_path, params$project_code, "merged_runs", sprintf("%s_%s", params$step_3b_analysis_date, params$user))
+output_path <- file.path(params$data_path, params$project_code, "merged_runs", sprintf("%s_%s", params$step_3a_analysis_date, params$user))
 
 write.csv(OTU_table, "OTU_table.csv")
 file.copy("./OTU_table.csv", file.path(glue("{output_path}/OTU_table.csv")))

--- a/Step4b_create_phyloseq_globalandlocal.Rmd
+++ b/Step4b_create_phyloseq_globalandlocal.Rmd
@@ -660,7 +660,7 @@ params
 
 ## Copy over OTU, TAX, samples to "merged_runs"
 ```{r}
-output_path <- file.path(params$data_path, params$project_code, "merged_runs", sprintf("%s_%s", params$step_3b_analysis_date, params$user))
+output_path <- file.path(params$data_path, params$project_code, "merged_runs", sprintf("%s_%s", params$step_3a_analysis_date, params$user))
 
 write.csv(OTU_table, "OTU_table.csv")
 file.copy("./OTU_table.csv", file.path(glue("{output_path}/OTU_table.csv")))


### PR DESCRIPTION
In the last code chunk, output_path uses the param for step **3b** analysis date, but the output directory has already been created using {step_3a_analysis_date}_{user}. 

This won't be an issue when Step 3a and Step 3b were run on the same date, but when run on different dates the directory uses the date for Step 3a.

Just changing to "params$step_**3a**_anlysis_date" in the output_path